### PR TITLE
Character 코드 수정 및 밸런스 수정

### DIFF
--- a/textRPG/Source/Game/Battle/ABattle.cpp
+++ b/textRPG/Source/Game/Battle/ABattle.cpp
@@ -108,7 +108,7 @@ void ABattle::PlayerAttackAction()
 	string EnemyName = Enemy->GetName();
 
 	// 몬스터에게 데미지
-	int Damage = Player->GetDamage();
+	int Damage = Player->GetDamage(); 
 	Enemy->TakeDamage(Damage);
 
 	// 로그 선언

--- a/textRPG/Source/Game/Character.cpp
+++ b/textRPG/Source/Game/Character.cpp
@@ -8,20 +8,10 @@
 #include "IItem.h"
 
 
-Character::Character() : Level{ 1 }, MaxExp{ 100 }, Exp(0), Damage(0)
+Character::Character() : Level{ 1 }, MaxExp{ 100 }, Exp(0)
 {
 	InitCharacter();
 	RandomizeStats();
-
-/*	Stats.OnStatChanged = [this](EStat statType, int newValue)
-	{
-			if (OnCharacterChanged)
-			{
-				OnCharacterChanged(ECharacterEvent::Stat, static_cast<int>(statType));
-			}
-
-	};
-*/
 
 	Inventory.clear(); //Item 추가 시 추가
 	
@@ -83,14 +73,8 @@ void Character::RaiseGold(int gold)
 // 생존 여부 반환 함수
 bool Character::IsDead()
 {
-	if (Stats.GetStat(EStat::CurHp) <= 0)
-	{
-		return true;
-	}
-	else
-	{
-		return false;
-	}
+	return (Stats.GetStat(EStat::CurHp) <= 0);
+
 }
 
 // 아이템 추가
@@ -143,12 +127,16 @@ void Character::UsePotion(int index)
 
 }
 
-int Character::TakeDamage(int damage)
+void Character::TakeDamage(int rawdamage)
 {
 	Status Stats = this->GetStatus();
 	int Defense =Stats.GetStat(EStat::Defense);
 
-	return std::max((damage - Defense),0);
+	int damage = std::max((rawdamage - Defense), 0);
+	int Hp = Stats.GetStat(EStat::CurHp) - damage;
+	Stats.SetStat(EStat::CurHp, Hp);
+
+	return ;
 }
 
 
@@ -219,28 +207,29 @@ void Character::RandomizeStats()
 	std::mt19937 gen(rd());
 
 	// 범위, 분포 설정
-	std::uniform_int_distribution<> distHp(150, 250);
-	std::uniform_int_distribution<> distStat(25, 35);
+	std::uniform_int_distribution<> distHp(100, 130);
+	std::uniform_int_distribution<> distPower(10, 15);
+	std::uniform_int_distribution<> distDefense(3, 5);
+	std::uniform_int_distribution<> distLuck(0, 10);
+
+	std::cout << "이  름 : " << Name << std::endl;
+	std::cout << "레  벨 : " << Level << std::endl;
+	std::wcout << "직  업 : " << Jobs->GetJobName() << std::endl;
 
 	int Choice = 0;
 	while (Choice != 1)
 	{
 		// 랜덤 스탯을 할당한다.
 		int maxHp = distHp(gen);
-		int power = distStat(gen);
-		int defense = distStat(gen);
-		int luck = distStat(gen);
+		int power = distPower(gen);
+		int defense = distDefense(gen);
+		int luck = distLuck(gen);
 
 		// 스탯 표시
 		std::cout << " 능력치를 설정해주세요!" << std::endl;
 		std::cout << "-------------------------------------------------" << std::endl;
 		std::cout << "                  PLAYER STATUS                  " << std::endl;
 		std::cout << "-------------------------------------------------" << std::endl;
-		std::cout << "이  름 : " << Name << std::endl;
-		
-		std::wcout << "직  업 : " << Jobs->GetJobName() << std::endl;
-		std::cout << "레  벨 : " << Level << std::endl;
-		std::cout << "경험치 : " << Exp << "/" << MaxExp << std::endl;
 		std::cout << "체  력 : " << maxHp << "/" << maxHp << std::endl;
 		std::cout << "공격력 : " << power << std::endl;
 		std::cout << "방어력 : " << defense << std::endl;
@@ -287,22 +276,21 @@ void Character::RandomizeStats()
 		}
 	}
 	// Damage 계산
-	float powerWeight = Jobs->GetPowerWeight();
-	float defenseWeight = Jobs->GetDefenseWeight();
-	float luckWeight = Jobs->GetLuckWeight();
-	float damage = Stats.StatToDamage(powerWeight, defenseWeight, luckWeight);
-	SetDamage(static_cast<int>(damage));
+	int powerWeight = Jobs->GetPowerWeight();
+	int defenseWeight = Jobs->GetDefenseWeight();
+	int luckWeight = Jobs->GetLuckWeight();
 }
 
 // 레벨업 함수
 void Character::LevelUp()
 {
-	while (Exp >= 100)
+	while (Exp >= MaxExp)
 	{
 		SetLevel(Level + 1);
 
 		// 100이 넘어갔을 경우 초과치를 다음 경험치에 추가합니다.
-		Exp = Exp - 100;
+		Exp = Exp - MaxExp;
+		MaxExp += 50;
 
 		
 	}
@@ -311,14 +299,14 @@ void Character::LevelUp()
 	int defense = Stats.GetStat(EStat::Defense);
 	int luck = Stats.GetStat(EStat::Luck);
 
-	float pWeight = Jobs->GetPowerWeight();
-	float dWeight = Jobs->GetDefenseWeight();
-	float lWeight = Jobs->GetLuckWeight();
+	int pWeight = Jobs->GetPowerWeight();
+	int dWeight = Jobs->GetDefenseWeight();
+	int lWeight = Jobs->GetLuckWeight();
 
-	maxHp += Level * 20;
-	power += static_cast<int>(3 * Level * pWeight);
-	defense += static_cast<int>(3 * Level * dWeight);
-	luck += static_cast<int>(3 * Level * lWeight);
+	maxHp += 20;
+	power += pWeight;
+	defense += dWeight;
+	luck += lWeight;
 
 	Stats.SetStat(EStat::MaxHp, maxHp);
 	Stats.SetStat(EStat::Power, power);
@@ -328,9 +316,6 @@ void Character::LevelUp()
 	// 체력 회복
 	Stats.SetStat(EStat::CurHp, maxHp);
 
-	// 데미지 재계산
-	float damage = Stats.StatToDamage(pWeight, dWeight, lWeight);
-	SetDamage(static_cast<int>(damage));
 
 	
 }
@@ -348,7 +333,6 @@ void Character::Display() const
 	int power = Stats.GetStat(EStat::Power);
 	int defense = Stats.GetStat(EStat::Defense);
 	int luck = Stats.GetStat(EStat::Luck);
-	int damage = GetDamage();
 
 	std::cout << "여러분의 선택이 캐릭터의 운명을 바꿉니다. 능력치를 설정해주세요!" << std::endl;
 	std::cout << "-------------------------------------------------" << std::endl;
@@ -362,6 +346,5 @@ void Character::Display() const
 	std::cout << "공격력 : " << power << std::endl;
 	std::cout << "방어력 : " << defense << std::endl;
 	std::cout << "행  운 : " << luck << std::endl;
-	std::cout << "데미지 : " << damage << std::endl;
 	std::cout << "-------------------------------------------------" << std::endl;
 }

--- a/textRPG/Source/Game/Character.h
+++ b/textRPG/Source/Game/Character.h
@@ -30,7 +30,6 @@ private:
 	int MaxExp;
 	int Exp;
 	int Gold;
-	int Damage;
 
 	Status Stats;
 	std::shared_ptr<IJob> Jobs;
@@ -61,7 +60,6 @@ public:
 	const std::string& GetName() const { return Name; }
 	int GetLevel() const { return Level; }
 	int GetExp() const { return Exp; }
-	int GetDamage() const { return Damage; }
 	int GetMaxExp() const { return MaxExp; }
 	int GetGold() const { return Gold; }
 	Status& GetStatus() { return Stats; }
@@ -69,7 +67,6 @@ public:
 
 	// Setter 함수
 	void SetExp(int exp);
-	void SetDamage(int damage) { Damage = damage; }
 	void SetLevel(int level);
 	void SetGold(int gold);
 
@@ -89,7 +86,7 @@ public:
 	bool IsDead();
 
 	// 데미집 입는 함수
-	int TakeDamage(int damage);
+	void TakeDamage(int rawdamage);
 	
 	// 인벤토리 추가
 	void AddItem(std::shared_ptr<IItem> item);

--- a/textRPG/Source/Game/IJob.h
+++ b/textRPG/Source/Game/IJob.h
@@ -8,8 +8,8 @@ public:
 	virtual ~IJob() = default;
 
 	// 순수 가상함수
-	virtual float GetPowerWeight() const = 0;
-	virtual float GetDefenseWeight() const = 0;
-	virtual float GetLuckWeight() const = 0;
+	virtual int GetPowerWeight() const = 0;
+	virtual int GetDefenseWeight() const = 0;
+	virtual int GetLuckWeight() const = 0;
 	virtual std::wstring GetJobName() const = 0;
 };

--- a/textRPG/Source/Game/Mage.h
+++ b/textRPG/Source/Game/Mage.h
@@ -4,9 +4,9 @@
 class Mage : public IJob
 {
 public:
-	float GetPowerWeight() const override { return 0.8f; }
-	float GetDefenseWeight() const override { return 1.2f; }
-	float GetLuckWeight() const override { return 1.0f; }
+	int GetPowerWeight() const override { return 3; }
+	int GetDefenseWeight() const override { return 3; }
+	int GetLuckWeight() const override { return  0; }
 
 	std::wstring GetJobName() const override { return L"Mage"; }
 };

--- a/textRPG/Source/Game/Status.cpp
+++ b/textRPG/Source/Game/Status.cpp
@@ -34,16 +34,3 @@ void Status::SetStat(EStat statType, int value)
 	}
 }
 
-float Status::StatToDamage(float powerWeight, float defenseWeight, float luckWeight)
-{
-	// 입력한 가중치에 각 스탯을 곱한다.
-	float power = static_cast<float>(GetStat(EStat::Power)) * powerWeight;
-	float defense = static_cast<float>(GetStat(EStat::Defense)) * defenseWeight;
-	float luck = static_cast<float>(GetStat(EStat::Luck)) * luckWeight;
-
-	// Damage 계산 로직 => (power + luck ) + defense
-	float damage = std::max(power + luck + defense, 0.0f);
-
-	return damage;
-	
-}

--- a/textRPG/Source/Game/Status.h
+++ b/textRPG/Source/Game/Status.h
@@ -28,6 +28,4 @@ public:
 	void SetStat(EStat statType, int value);
 
 	
-	// 스탯 -> 데미지
-	float StatToDamage(float powerWeight, float defenseWeight, float luckWeight);
 };

--- a/textRPG/Source/Game/Thief.h
+++ b/textRPG/Source/Game/Thief.h
@@ -4,9 +4,9 @@
 class Thief : public IJob
 {
 public:
-	float GetPowerWeight() const override { return 1.0f; }
-	float GetDefenseWeight() const override { return 0.8f; }
-	float GetLuckWeight() const override { return 1.2f; }
+	int GetPowerWeight() const override { return 3; }
+	int GetDefenseWeight() const override { return 1; }
+	int GetLuckWeight() const override { return 7; }
 
 	std::wstring GetJobName() const override { return L"Thief"; }
 };

--- a/textRPG/Source/Game/Warrior.h
+++ b/textRPG/Source/Game/Warrior.h
@@ -5,9 +5,9 @@ class Warrior : public IJob
 {
 public:
 	// Warrior의 각 능력치 가중치
-	float GetPowerWeight() const override { return 1.2f; }
-	float GetDefenseWeight() const override { return 1.0f; }
-	float GetLuckWeight() const override { return 0.8f; }
+	int GetPowerWeight() const override { return 5; }
+	int GetDefenseWeight() const override { return 1; }
+	int GetLuckWeight() const override { return 0; }
 	
 	std::wstring GetJobName() const override { return L"Warrior"; }
 };

--- a/textRPG/textRPG.vcxproj
+++ b/textRPG/textRPG.vcxproj
@@ -61,8 +61,8 @@
     <ClInclude Include="Source\Game\Creatures\Slime.h" />
     <ClInclude Include="Source\Game\Creatures\Witch.h" />
     <ClInclude Include="Source\Game\Equipment.h" />
+    <ClInclude Include="Source\Game\IJob.h" />
     <ClInclude Include="Source\Game\InputReceiver.h" />
-    <ClInclude Include="Source\Game\Job.h" />
     <ClInclude Include="Source\Game\LogicHelper.h" />
     <ClInclude Include="Source\Game\Mage.h" />
     <ClInclude Include="Source\Game\Managers\GameManager.h" />

--- a/textRPG/textRPG.vcxproj.filters
+++ b/textRPG/textRPG.vcxproj.filters
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="리소스 파일">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
     <Filter Include="Source">
       <UniqueIdentifier>{36bb499e-a83b-457c-9f65-a0889d2ff2ba}</UniqueIdentifier>
     </Filter>
@@ -19,6 +15,9 @@
     </Filter>
     <Filter Include="Source\Game\Battle">
       <UniqueIdentifier>{d0887c83-a7f9-426e-a55b-d01a19b49d49}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source\Game\Character">
+      <UniqueIdentifier>{0eef7962-250f-417e-84c3-cb4264685460}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -43,9 +42,6 @@
     <ClCompile Include="Source\Game\ConstantContainer.cpp">
       <Filter>Source\Game</Filter>
     </ClCompile>
-    <ClCompile Include="Source\Game\Character.cpp">
-      <Filter>Source\Game</Filter>
-    </ClCompile>
     <ClCompile Include="Source\Game\Managers\GameManager.cpp">
       <Filter>Source\Game\Managers</Filter>
     </ClCompile>
@@ -61,7 +57,6 @@
     <ClCompile Include="Source\Game\TileMap.cpp">
       <Filter>Source\Game</Filter>
     </ClCompile>
-    <ClCompile Include="Source\Game\Status.cpp" />
     <ClCompile Include="Source\Game\Creatures\Goblin.cpp">
       <Filter>Source\Game\Creatures</Filter>
     </ClCompile>
@@ -85,7 +80,7 @@
     </ClCompile>
     <ClCompile Include="Source\Game\Equipment.cpp">
       <Filter>Source\Game</Filter>
-	</ClCompile>
+    </ClCompile>
     <ClCompile Include="Source\Game\Battle\ABattle.cpp">
       <Filter>Source\Game\Battle</Filter>
     </ClCompile>
@@ -94,6 +89,12 @@
     </ClCompile>
     <ClCompile Include="Source\Game\Battle\HandBattle.cpp">
       <Filter>Source\Game\Battle</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Game\Character.cpp">
+      <Filter>Source\Game\Character</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Game\Status.cpp">
+      <Filter>Source\Game\Character</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -115,9 +116,6 @@
     <ClInclude Include="Source\Game\ConstantContainer.h">
       <Filter>Source\Game</Filter>
     </ClInclude>
-    <ClInclude Include="Source\Game\Character.h">
-      <Filter>Source\Game</Filter>
-    </ClInclude>
     <ClInclude Include="Source\Game\Managers\UIManager.h">
       <Filter>Source\Game\Managers</Filter>
     </ClInclude>
@@ -133,10 +131,6 @@
     <ClInclude Include="Source\Game\TileMap.h">
       <Filter>Source\Game</Filter>
     </ClInclude>
-    <ClInclude Include="Source\Game\Job.h" />
-    <ClInclude Include="Source\Game\Mage.h" />
-    <ClInclude Include="Source\Game\Status.h" />
-    <ClInclude Include="Source\Game\Thief.h" />
     <ClInclude Include="Source\Game\Creatures\Goblin.h">
       <Filter>Source\Game\Creatures</Filter>
     </ClInclude>
@@ -155,15 +149,9 @@
     <ClInclude Include="Source\Game\Creatures\Slime.h">
       <Filter>Source\Game\Creatures</Filter>
     </ClInclude>
-    <ClInclude Include="Source\Game\Warrior.h">
-      <Filter>Source\Game\Creatures</Filter>
-    </ClInclude>
     <ClInclude Include="Source\Game\Creatures\Witch.h">
       <Filter>Source\Game\Creatures</Filter>
     </ClInclude>
-    <ClInclude Include="Source\Game\Equipment.h">
-      <Filter>Source</Filter>
-    </ClInclude>    
     <ClInclude Include="Source\Game\Battle\ABattle.h">
       <Filter>Source\Game\Battle</Filter>
     </ClInclude>
@@ -172,6 +160,27 @@
     </ClInclude>
     <ClInclude Include="Source\Game\Battle\HandBattle.h">
       <Filter>Source\Game\Battle</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Game\Mage.h">
+      <Filter>Source\Game\Character</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Game\Thief.h">
+      <Filter>Source\Game\Character</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Game\Character.h">
+      <Filter>Source\Game\Character</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Game\Status.h">
+      <Filter>Source\Game\Character</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Game\Equipment.h">
+      <Filter>Source\Game</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Game\Warrior.h">
+      <Filter>Source\Game\Character</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Game\IJob.h">
+      <Filter>Source\Game\Character</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
-Damage 삭제
-레벨 업시 증가하는 계수 float -> int로 변환
-takeDamage 수정

경험치

- 필요 경험치를 레벨이 오름에 따라 늘릴지 안 늘릴지 → 정해야 함
- 일단 100 대신 MaxExp로 설정한다.

전투 밸런스

- 데미지 계산
    - power =  damage ⇒ ++ 부족한 데미지는 밸런스를 장비로 맞추자 ★
    - (각 스탯 * 가중치)의 합 = damage ⇒ 가중치는 어느 정도로?

- 레벨업 시 스탯 증가량

Hp   ⇒ 20

가중치

Warrior = { 5, 1, 0}

Mage = {3, 3, 0}

Thief = {3, 1, 7}

- 초기 스탯 (몬스터 Hp는 1/4 정도 )

Hp: 100 ~ 130 

Pow: 10 ~ 15

Def: 3 ~ 5

Luck: 0~10