### PR TITLE
맵의 크기를 16, 8로 수정, TileMap의 크기에 따른 버그 수정

### DIFF
--- a/textRPG/Source/Game/Managers/GameManager.h
+++ b/textRPG/Source/Game/Managers/GameManager.h
@@ -30,7 +30,7 @@ public:
 
 		if (Instance.TileMapIsntance == nullptr)
 		{
-			Instance.TileMapIsntance = std::make_unique<TileMap>(5, 5);
+			Instance.TileMapIsntance = std::make_unique<TileMap>(16, 8);
 		}
 
 		return Instance;

--- a/textRPG/Source/Game/TileMap.cpp
+++ b/textRPG/Source/Game/TileMap.cpp
@@ -51,7 +51,7 @@ FAvailableDirection TileMap::GetAvailableDirection()
 
 bool TileMap::CanTraverse(int X, int Y) const
 {
-	return (X >= 0 && X < Width && Y >= 0 && Y < Height) && TileGrid[X][Y] != ETile::Block;
+	return (X >= 0 && X < Height && Y >= 0 && Y < Width) && TileGrid[X][Y] != ETile::Block;
 }
 
 std::vector<std::vector<ETile>> TileMap::GetCurretnMapData()

--- a/textRPG/Source/Game/TileMap.cpp
+++ b/textRPG/Source/Game/TileMap.cpp
@@ -83,8 +83,8 @@ void TileMap::GenerateTestMap()
 	// To-Do : 초기화 과정에서 Tile Type과 Art Type을 한 번에 설정할 수 있도록 하는 기능 구현
 	TileGrid[0][0] = ETile::Village1;
 	TileArtGrid[0][0] = EArtList::Test;
-	TileGrid[Width - 1][0] = ETile::Village2;
-	TileArtGrid[Width - 1][0] = EArtList::Test;
-	TileGrid[Width - 1][Height - 1] = ETile::DemonLordCastle;
-	TileArtGrid[Width - 1][Height - 1] = EArtList::Castle1;
+	TileGrid[Height - 1][0] = ETile::Village2;
+	TileArtGrid[Height - 1][0] = EArtList::Test;
+	TileGrid[Height - 1][Width - 1] = ETile::DemonLordCastle;
+	TileArtGrid[Height - 1][Width - 1] = EArtList::Castle1;
 }


### PR DESCRIPTION
- Map의 크기를 16, 8로 수정, 가로가 더 좁기 때문에 가로가 큰 맵으로 수정함
- TileMap에서 X,Y를 설정할 때 Width, Height를 잘못 비교하고 있던 오류 수정