### PR TITLE
🐛 bugfix LogicHelper

### DIFF
--- a/textRPG/Source/Game/LogicHelper.cpp
+++ b/textRPG/Source/Game/LogicHelper.cpp
@@ -46,7 +46,7 @@ std::wstring LogicHelper::StringToWString(const std::string& Str)
 
     // 변환 수행
     MultiByteToWideChar(CP_UTF8, 0, Str.c_str(), -1, &NewWString[0], Size);
-
+    NewWString.resize(Size - 1);
     return NewWString;
 }
 


### PR DESCRIPTION
- StringToWString : 변환 결과 뒤에 널문자 제거가 안 되는 점 해결